### PR TITLE
modify base url in jsonconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "app/",
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
To make importing more consistent as project gets more complex.
Here's a link on this topic from [next.js documentation](https://nextjs.org/docs/pages/building-your-application/configuring/absolute-imports-and-module-aliases).

With this change, by default, all imports will reference the /app directory.

Instead of **import {someThing} from ' ../../components/someThing.jsx '** , If /components is in the /app directory, you can just write:

**import {someThing} from 'components/someThing.jsx'**

If we end up with deeper directories, this will come in handy.

One issue with this change is that currently the /models directory is located outside of the app directory. It can still be accessed with the relative path as you have it imported. Not a big deal, it's just that anything outside of the app directory (if this pull request is merged) wouldn't be accessible with the 'shortcut'.  Is there some functional reason it should not be in the app directory? 
