### PR TITLE
add react-hook-form register component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,76 @@
 @tailwind base;
 @tailwind components;
+
+
+:root {
+    /* this are placeholders for future vars, the vars
+    will be mapped to the tailwind config for ease of use
+    while developing */
+    --primary-color: #961aa2;
+    --primary-color-hover: #66126e; 
+    --secondary-color: #cc8844;
+    --nav-link-color: #FFFFFFE6;
+
+  }
+
+  /* Base - variables, html elements
+  TODO: Move body into another file? */
+
+  @layer base {
+    body {
+        background-color: #F5F5F5;
+ 
+      }
+  }
+
+
+  /* COMPONENTS */
+@layer components {
+
+/* BUTTON */
+
+.btn {
+    @apply w-full border shadow py-3 px-6 font-semibold text-lg rounded bg-blue-500 text-white
+}
+
+/* FORM CSS */
+form {
+ @apply w-full max-w-lg m-auto py-10 mt-10 px-10 border border-[#ddd] border-transparent bg-[#FFFFFF] shadow-md
+}
+
+.form__field-container  {
+    @apply mb-10
+}
+
+.form__label {
+    @apply text-gray-600 font-medium
+}
+
+.form__input {
+    @apply border-solid border-gray-300 border py-2 px-4 w-full rounded
+}
+
+.form__error {
+     @apply text-sm text-red-400
+}
+
+.form__submit-button {
+    @apply bg-primary hover:bg-primary-hover text-green-100 
+}
+
+}
+
+
+/* UTILITIES */
+/* the @tailwind directive is here so that any utility class supercededes all other classes */
 @tailwind utilities;
+@layer utilities {
+    /* .container-nav {
+        @apply mx-auto  px-4
+    } */
+
+    .nav-link {
+        @apply text-nav-link text-2xl py-2 px-4 hover:text-white
+    }
+
+}

--- a/app/register2/RegisterForm2.jsx
+++ b/app/register2/RegisterForm2.jsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+
+export default function RegisterForm2({ title }) {
+  const [data, setData] = useState();
+  const [errMsgs, setErrMsgs] = useState();
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm();
+
+
+  const onSubmit = async (e) => {
+    //e.preventDefault() not needed with react-hook-form because it is handled by the handleSubmit function from react-hook-form
+
+    // e.preventDefault();
+
+    console.log('submit data: ', e)
+
+    //this creation of formData is not needed with react-hook-form
+    //because the data is already in the e object
+
+    // const formData = new FormData(e);
+    // const { firstName, lastName, email, password, password2 } =
+    //   Object.fromEntries(formData);
+
+
+    //instead of this, we can just use the e object and destructure it to get the data
+    const { firstName, lastName, email, password, password2 } = e;
+
+    try {
+      const res = await fetch("/api/auth/register-user", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          firstName,
+          lastName,
+          email,
+          password,
+          password2,
+        }),
+      });
+
+
+
+      if (res.ok) {
+        router.push("/login");
+      } else {
+        const errData = await res.json();
+        setErrMsgs(errData);
+      }
+    } catch (err) {
+      console.log(`Error in app/register-user ${err}`);
+      router.push("/error-page");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="mb-10">{title}</div>
+
+      <div className="form__field-container">
+        <input
+          placeholder="First Name"
+          className="border-solid border-gray-300 border py-2 px-4 w-full rounded"
+          {...register("firstName", { required: "First Name is required" })}
+        />
+        {errors.firstName?.message && (
+          <p className="text-sm text-red-400">{errors.firstName.message}</p>
+        )}
+      </div>
+
+      <div className="form__field-container">
+        <input
+          placeholder="Last Name"
+          className="form__input"
+          {...register("lastName", { required: "Last Name is required"})}
+        />
+        {errors.lastName?.message && (
+          <p className="form__error">{errors.lastName.message}</p>
+        )}
+      </div>
+
+      <div className="form__field-container">
+        <input
+          placeholder="Email"
+          className="form__input"
+          {...register("email", {
+            required: "Email required"})}
+        />
+        {errors.email?.message && (
+          <p className="form__error">{errors.email.message}</p>
+        )}
+      </div>
+
+      <div className="form__field-container">
+        <input
+          placeholder="Password"
+          className="form__input"
+          {...register("password", {
+            required: "Password required"})}
+        />
+        {errors.password?.message && (
+          <p className="form__error">{errors.password.message}</p>
+        )}
+      </div>
+
+      <div className="form__field-container">
+        <input
+          placeholder="Confirm Password"
+          className="form__input"
+          {...register("password2", {required: "Password required"})}
+        />
+        {errors.password2?.message && (
+          <p className="form__error">{errors.password2.message}</p>
+        )}
+      </div>
+
+      <button className=" btn form__submit-button">Submit</button>
+    </form>
+  );
+}

--- a/app/register2/page.jsx
+++ b/app/register2/page.jsx
@@ -1,0 +1,10 @@
+
+
+import RegisterForm2 from "./RegisterForm2.jsx";
+export default function Page() {
+  return (
+    <div>
+      <RegisterForm2 title="Register" />
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next-auth": "^4.23.1",
         "pg": "^8.11.3",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-hook-form": "^7.46.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.15",
@@ -1765,6 +1766,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.46.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.46.1.tgz",
+      "integrity": "sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next-auth": "^4.23.1",
     "pg": "^8.11.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.46.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.15",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,30 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./app/**/*.{js,ts,jsx,tsx,mdx}", // Note the addition of the `app` directory.
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    // "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    screens: {
+      'sm': '640px',
+      'md': '768px',
+      'lg': '1024px',
+      'xl':'1280px',
+      '2xl':'1536px'
+    },
+    container: {
+      center: true,
+      padding: '2rem'
+    },
+
+    extend: {
+      colors: {
+        'nav-link':'var(--nav-link-color)',
+        'primary': {DEFAULT: 'var(--primary-color)'},
+        'primary-hover': 'var(--primary-color-hover)'
+      }
+    },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
I made a temporary route called 'register2' and a component called RegisterForm2 so that you can compare the standard form to the form using react-hook-form. Turns out they are very similar!

Primary differences:

1. I moved the handleSubmit function to the Form component instead of the page
2. All state management is in the RegisterForm2 component.
3. prevent.Default is not needed with react-hook-form
4. no need to create FormData object as react-hook-form handles this behind the scenes

In RegisterForm2, my comments explain the differences.

