### PR TITLE
Correct next/link import in RegisterForm

### DIFF
--- a/app/login/LoginForm.jsx
+++ b/app/login/LoginForm.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import Link from "next/Link";
+import Link from "next/link";
 import MessageList from "@/components/MessageList";
 
 export default function LoginForm({ title }) {

--- a/app/register/RegisterForm.jsx
+++ b/app/register/RegisterForm.jsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
-import Link from "next/Link";
+import Link from "next/link";
 import MessageList from "components/MessageList";
 
 export default function RegisterForm({ title }) {


### PR DESCRIPTION
The import in RegisterForm and LoginForm used an uppercase 'Link' in the next/link import stateement when it should be lowercased.

```
import Link from "next/link";
```

This was throwing a few errors. There was also an error about importing the RegisterForm and LoginForm. I believe this was resolved by updating the next/link import statement.

